### PR TITLE
utils: Change yuzu to yuzuOld

### DIFF
--- a/source/utils.h
+++ b/source/utils.h
@@ -194,7 +194,7 @@ enum cfwName {
     atmosphere,
     sxos,
     ReiNX,
-    yuzu,
+    yuzuOld,
 };
 cfwName getCFW()
 {
@@ -209,7 +209,7 @@ cfwName getCFW()
     splExit();
     if (R_SUCCEEDED(res))
         return atmosphere;
-    return yuzu;
+    return yuzuOld;
 }
 
 std::string dataArcPath(cfwName cfw) {
@@ -227,7 +227,7 @@ std::string dataArcPath(cfwName cfw) {
         case ReiNX:
             path = "/ReiNX/contents/01006A800016E000/romfs/data.arc";
             break;
-        case yuzu:
+        case yuzuOld:
             path = "/yuzu/load/01006A800016E000/UMM/romfs/data.arc";
             break;
     }


### PR DESCRIPTION
I have implemented the spl service in https://github.com/yuzu-emu/yuzu/pull/6472. Now we report that we are Atmosphere.
This will change the path that UMM searches to Atmosphere's mod directory.

If possible, could you update the page on https://gamebanana.com/tuts/13154 to reflect the new change once the PR in yuzu is merged.